### PR TITLE
Add global rate limiting

### DIFF
--- a/internal/controller/autoscaler/const.go
+++ b/internal/controller/autoscaler/const.go
@@ -14,7 +14,10 @@
 
 package autoscaler
 
+import "time"
+
 const (
 	// StatusTypeReady represents the status of the resource
 	StatusTypeReady = "Ready"
+	GlobalRateLimit = 5 * time.Second
 )

--- a/internal/controller/autoscaler/robustscalingnormalizer_controller.go
+++ b/internal/controller/autoscaler/robustscalingnormalizer_controller.go
@@ -19,6 +19,8 @@ package autoscaler
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -48,6 +50,8 @@ type RobustScalingNormalizerReconciler struct {
 	Scheme *runtime.Scheme
 
 	Normalizer robustscaling.Normalizer
+
+	lastReconciled sync.Map
 }
 
 var (
@@ -88,6 +92,14 @@ func (r *RobustScalingNormalizerReconciler) Reconcile(ctx context.Context, req c
 	log := log.FromContext(ctx)
 	log.V(2).Info("Received reconcile request")
 	defer log.V(2).Info("Reconcile request completed")
+
+	if lastTimeRaw, exists := r.lastReconciled.Load(req.NamespacedName.String()); exists {
+		lastTime := lastTimeRaw.(time.Time)
+		if time.Since(lastTime) < GlobalRateLimit {
+			log.V(2).Info("Rate limiting", "since", time.Since(lastTime))
+			return ctrl.Result{RequeueAfter: GlobalRateLimit - time.Since(lastTime)}, nil
+		}
+	}
 
 	normalizer := &autoscaler.RobustScalingNormalizer{}
 	if err := r.Get(ctx, req.NamespacedName, normalizer); err != nil {


### PR DESCRIPTION
Reconciliation for the same resource is not allowed more frequently than once every 5 seconds. This helps to avoid "object has been modified" errors and inconsistent behavior and random e2e tests showing that STS was scaled 2-3 times instead of 1.