### PR TITLE
Remove polling period from evaluator

### DIFF
--- a/internal/controller/autoscaler/mostwantedtwophasehysteresisevaluation_controller.go
+++ b/internal/controller/autoscaler/mostwantedtwophasehysteresisevaluation_controller.go
@@ -336,7 +336,7 @@ func (r *MostWantedTwoPhaseHysteresisEvaluationReconciler) Reconcile(ctx context
 	}
 	log.Info("Resource status updated", "projection", len(evaluation.Status.Projection))
 
-	// We should get a reconciliation request when poller is changed
+	// We should get a reconciliation request on poller changes
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
Evaluator will receive events when poller changes, so naturally this option was not even used. Although it could become a problem for external pollers, but we will cross that bridge when (if) we get there.

Actual change was already pushed to main by accident https://github.com/plumber-cd/argocd-autoscaler/commit/6ae744eb4e5c464aa90d6d8a9dc2d822cd6d2678
Just making a PR for the changelog.