### PR TITLE
MostWantedTwoPhaseHysteresisEvaluation: cleanup stale history on new election

### DIFF
--- a/internal/controller/autoscaler/mostwantedtwophasehysteresisevaluation_controller.go
+++ b/internal/controller/autoscaler/mostwantedtwophasehysteresisevaluation_controller.go
@@ -347,7 +347,13 @@ func (r *MostWantedTwoPhaseHysteresisEvaluationReconciler) Reconcile(ctx context
 		time.Since(evaluation.Status.LastEvaluationTimestamp.Time) >= evaluation.Spec.StabilizationPeriod.Duration {
 		evaluation.Status.Replicas = evaluation.Status.Projection
 		evaluation.Status.LastEvaluationTimestamp = ptr.To(metav1.Now())
-		evaluation.Status.History = []autoscalerv1alpha1.MostWantedTwoPhaseHysteresisEvaluationStatusHistoricalRecord{}
+		evaluation.Status.History = []autoscalerv1alpha1.MostWantedTwoPhaseHysteresisEvaluationStatusHistoricalRecord{
+			{
+				Timestamp:    metav1.Now(),
+				ReplicasHash: Sha256(evaluation.Status.Replicas.SerializeToString()),
+				SeenTimes:    1,
+			},
+		}
 		log.Info("New partitioning has won",
 			"replicas", len(evaluation.Status.Replicas), "lastEvaluationTimestamp", evaluation.Status.LastEvaluationTimestamp)
 	}

--- a/internal/controller/autoscaler/mostwantedtwophasehysteresisevaluation_controller_test.go
+++ b/internal/controller/autoscaler/mostwantedtwophasehysteresisevaluation_controller_test.go
@@ -383,9 +383,11 @@ var _ = Describe("MostWantedTwoPhaseHysteresisEvaluation Controller", func() {
 				)
 				samplePartition.Get()
 				history := run.Container().Object().Status.History
-				Expect(history).To(HaveLen(2))
-				Expect(history[0].SeenTimes).To(Equal(int32(3)))
-				Expect(history[1].SeenTimes).To(Equal(int32(3)))
+				Expect(history).To(HaveLen(1))
+				Expect(history[0].ReplicasHash).To(Equal(
+					Sha256(samplePartition.Object().Status.Replicas.SerializeToString())))
+				Expect(history[0].SeenTimes).To(Equal(int32(1)))
+				Expect(history[0].Timestamp.Time).To(BeTemporally("~", time.Now(), time.Second))
 
 				By("Checking evaluation results")
 				Expect(run.Container().Object().Status.Replicas).To(Equal(samplePartition.Object().Status.Replicas))


### PR DESCRIPTION
Over time the history counters are only going up, so the longer we exist since the beginning of recording the history - the less chance re-balancing will ever happen because every election cycle candidates get to keep old votes and add them up to new votes. It becomes progressively longer for a new true partition to win. This fix voids the history at the beginning of each cycle.